### PR TITLE
Bump dependency version to v0.28.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/klauspost/compress v1.15.1
 	github.com/labstack/echo/v4 v4.5.0
 	github.com/onflow/cadence v0.28.0
-	github.com/onflow/flow-go v0.28.5
+	github.com/onflow/flow-go v0.28.11
 	github.com/onflow/flow-go-sdk v0.29.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/tsdb v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -1222,8 +1222,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa/go.mod h1:JB2hWVxUjhMshUDNVQKfn4dzhhawOO+i3XjlhLMV5MM=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go v0.28.5 h1:IA+cNcaA7d02689zDuYUN6ygkrO3/jnTE36naf9A0KE=
-github.com/onflow/flow-go v0.28.5/go.mod h1:lNbN/bqUMITOiq+imWhKOWtDCOAvFT6/zovB+bI/MQg=
+github.com/onflow/flow-go v0.28.11 h1:vttwAgcW/vwF3s6J6vn50dFq6dXzSzMas545qacUbpY=
+github.com/onflow/flow-go v0.28.11/go.mod h1:lNbN/bqUMITOiq+imWhKOWtDCOAvFT6/zovB+bI/MQg=
 github.com/onflow/flow-go-sdk v0.20.0/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
 github.com/onflow/flow-go-sdk v0.29.0 h1:dTQvTZkHsHMU3eEnHaE8JE2SOPeAIYx5CgTul5MgDYE=
 github.com/onflow/flow-go-sdk v0.29.0/go.mod h1:58y6+IddssbrUnrCdYXJuAh64cMHvxy+InUfBA3e8v0=


### PR DESCRIPTION
## Goal of this PR
Bump version of `flow-go` so the `cbor` files are read correctly