### PR TITLE
Reduce concurrency factor for register value lookup

### DIFF
--- a/service/index/reader.go
+++ b/service/index/reader.go
@@ -29,7 +29,7 @@ import (
 )
 
 // ConcurrentPathReadLimit sets the number of concurrent paths in the Values lookup
-const ConcurrentPathReadLimit int = 5000
+const ConcurrentPathReadLimit int = 128
 
 // Reader implements the `index.Reader` interface on top of the DPS server's
 // Badger database index.


### PR DESCRIPTION
## Goal of this PR
Fix concurrency factor so we don't use too much memory in register lookups
