### PR TITLE
Improve logging to record index reader values function execution time

### DIFF
--- a/api/archive/server_integration_test.go
+++ b/api/archive/server_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -39,13 +40,14 @@ func TestIntegrationServer_GetFirst(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -64,6 +66,7 @@ func TestIntegrationServer_GetFirst(t *testing.T) {
 	t.Run("handles indexer failure on First", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -71,7 +74,7 @@ func TestIntegrationServer_GetFirst(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -87,13 +90,14 @@ func TestIntegrationServer_GetLast(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -112,6 +116,7 @@ func TestIntegrationServer_GetLast(t *testing.T) {
 	t.Run("handles indexer failure on Last", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -119,7 +124,7 @@ func TestIntegrationServer_GetLast(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -137,13 +142,14 @@ func TestIntegrationServer_GetHeightForBlock(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -164,6 +170,7 @@ func TestIntegrationServer_GetHeightForBlock(t *testing.T) {
 	t.Run("handles indexer failure on HeightForBlock", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -171,7 +178,7 @@ func TestIntegrationServer_GetHeightForBlock(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -191,13 +198,14 @@ func TestIntegrationServer_GetCommit(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -219,6 +227,7 @@ func TestIntegrationServer_GetCommit(t *testing.T) {
 	t.Run("handles indexer failure on Commit", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -226,7 +235,7 @@ func TestIntegrationServer_GetCommit(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -246,13 +255,14 @@ func TestIntegrationServer_GetHeader(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -277,6 +287,7 @@ func TestIntegrationServer_GetHeader(t *testing.T) {
 	t.Run("handles indexer failure on Header", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -284,7 +295,7 @@ func TestIntegrationServer_GetHeader(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -309,13 +320,14 @@ func TestIntegrationServer_GetEvents(t *testing.T) {
 	t.Run("nominal case without type specified", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -342,13 +354,14 @@ func TestIntegrationServer_GetEvents(t *testing.T) {
 	t.Run("nominal case with type specified", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -376,6 +389,7 @@ func TestIntegrationServer_GetEvents(t *testing.T) {
 	t.Run("handles indexer failure on Events", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -383,7 +397,7 @@ func TestIntegrationServer_GetEvents(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -404,13 +418,14 @@ func TestIntegrationServer_GetRegisterValues(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -440,13 +455,14 @@ func TestIntegrationServer_GetRegisterValues(t *testing.T) {
 	t.Run("handles conversion error", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -469,6 +485,7 @@ func TestIntegrationServer_GetRegisterValues(t *testing.T) {
 	t.Run("handles indexer failure on Values", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -476,7 +493,7 @@ func TestIntegrationServer_GetRegisterValues(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		server := archive.NewServer(reader, codec)
 
 		req := &archive.GetRegisterValuesRequest{
@@ -496,13 +513,14 @@ func TestIntegrationServer_GetCollection(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -527,6 +545,7 @@ func TestIntegrationServer_GetCollection(t *testing.T) {
 	t.Run("handles indexer failure on Collection", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -534,7 +553,7 @@ func TestIntegrationServer_GetCollection(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -554,13 +573,14 @@ func TestIntegrationServer_ListCollectionsForHeight(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -587,6 +607,7 @@ func TestIntegrationServer_ListCollectionsForHeight(t *testing.T) {
 	t.Run("handles indexer failure on CollectionsByHeight", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -594,7 +615,7 @@ func TestIntegrationServer_ListCollectionsForHeight(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -614,13 +635,14 @@ func TestIntegrationServer_GetGuarantee(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -645,6 +667,7 @@ func TestIntegrationServer_GetGuarantee(t *testing.T) {
 	t.Run("handles indexer failure on Guarantee", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -652,7 +675,7 @@ func TestIntegrationServer_GetGuarantee(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -672,13 +695,14 @@ func TestIntegrationServer_GetTransaction(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -703,6 +727,7 @@ func TestIntegrationServer_GetTransaction(t *testing.T) {
 	t.Run("handles indexer failure on Transaction", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -710,7 +735,7 @@ func TestIntegrationServer_GetTransaction(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -730,13 +755,14 @@ func TestIntegrationServer_GetHeightForTransaction(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -758,6 +784,7 @@ func TestIntegrationServer_GetHeightForTransaction(t *testing.T) {
 	t.Run("handles indexer failure on HeightForTransaction", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -765,7 +792,7 @@ func TestIntegrationServer_GetHeightForTransaction(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -785,13 +812,14 @@ func TestIntegrationServer_ListTransactionsForHeight(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -818,6 +846,7 @@ func TestIntegrationServer_ListTransactionsForHeight(t *testing.T) {
 	t.Run("handles indexer failure on TransactionsByHeight", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -825,7 +854,7 @@ func TestIntegrationServer_ListTransactionsForHeight(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -845,13 +874,14 @@ func TestIntegrationServer_GetResult(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -876,6 +906,7 @@ func TestIntegrationServer_GetResult(t *testing.T) {
 	t.Run("handles indexer failure on Result", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -883,7 +914,7 @@ func TestIntegrationServer_GetResult(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -903,13 +934,14 @@ func TestIntegrationServer_GetSeal(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -934,6 +966,7 @@ func TestIntegrationServer_GetSeal(t *testing.T) {
 	t.Run("handles indexer failure on Seal", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -941,7 +974,7 @@ func TestIntegrationServer_GetSeal(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 
@@ -961,13 +994,14 @@ func TestIntegrationServer_ListSealsForHeight(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
 
 		disk := storage.New(codec)
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 		writer := index.NewWriter(db, disk)
 
 		// Insert mock data in database.
@@ -994,6 +1028,7 @@ func TestIntegrationServer_ListSealsForHeight(t *testing.T) {
 	t.Run("handles indexer failure on SealsByHeight", func(t *testing.T) {
 		t.Parallel()
 
+		log := zerolog.Nop()
 		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
@@ -1001,7 +1036,7 @@ func TestIntegrationServer_ListSealsForHeight(t *testing.T) {
 
 		disk := storage.New(codec)
 		// No data is written in the database, so the index should fail to retrieve anything.
-		reader := index.NewReader(db, disk)
+		reader := index.NewReader(log, db, disk)
 
 		server := archive.NewServer(reader, codec)
 

--- a/cmd/flow-archive-indexer/main.go
+++ b/cmd/flow-archive-indexer/main.go
@@ -116,7 +116,7 @@ func run() int {
 	storage := storage.New(codec)
 
 	// Check if index already exists.
-	read := index.NewReader(indexDB, storage)
+	read := index.NewReader(log, indexDB, storage)
 	first, err := read.First()
 	empty := errors.Is(err, badger.ErrKeyNotFound)
 	if err != nil && !empty {

--- a/cmd/flow-archive-live/main.go
+++ b/cmd/flow-archive-live/main.go
@@ -159,7 +159,7 @@ func run() int {
 	// shutting down.
 	codec := zbor.NewCodec()
 	storage := storage.New(codec)
-	read := index.NewReader(indexDB, storage)
+	read := index.NewReader(log, indexDB, storage)
 	first, err := read.First()
 	if err != nil && !errors.Is(err, badger.ErrKeyNotFound) {
 		log.Error().Err(err).Msg("could not get first height from index reader")

--- a/cmd/flow-archive-server/main.go
+++ b/cmd/flow-archive-server/main.go
@@ -16,12 +16,13 @@ package main
 
 import (
 	"errors"
-	"github.com/onflow/flow-archive/service/metrics"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"time"
+
+	"github.com/onflow/flow-archive/service/metrics"
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/rs/zerolog"
@@ -105,7 +106,7 @@ func run() int {
 			logging.StreamServerInterceptor(grpczerolog.InterceptorLogger(log), opts...),
 		),
 	)
-	index := index.NewReader(db, storage)
+	index := index.NewReader(log, db, storage)
 	var server *api.Server
 	if flagTracing {
 		tracer, err := metrics.NewTracer(log, "archive")

--- a/cmd/restore-index-snapshot/main.go
+++ b/cmd/restore-index-snapshot/main.go
@@ -83,7 +83,7 @@ func run() int {
 	defer db.Close()
 
 	// Check if the database is empty.
-	index := index.NewReader(db, storage.New(zbor.NewCodec()))
+	index := index.NewReader(log, db, storage.New(zbor.NewCodec()))
 	_, err = index.First()
 	if err == nil {
 		log.Error().Msg("database directory already contains index database")

--- a/service/index/index_integration_test.go
+++ b/service/index/index_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -328,7 +329,9 @@ func setupIndex(t *testing.T) (*index.Reader, *index.Writer, *badger.DB) {
 
 	lib := storage.New(codec)
 
-	reader := index.NewReader(db, lib)
+	log := zerolog.Nop()
+
+	reader := index.NewReader(log, db, lib)
 	writer := index.NewWriter(db, lib, index.WithConcurrentTransactions(4))
 
 	return reader, writer, db

--- a/service/index/reader.go
+++ b/service/index/reader.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -92,6 +93,7 @@ func (r *Reader) Header(height uint64) (*flow.Header, error) {
 // For compatibility with existing Flow execution node code, a path that is not
 // found within the indexed execution state returns a nil value without error.
 func (r *Reader) Values(height uint64, paths []ledger.Path) ([]ledger.Value, error) {
+	t := time.Now()
 
 	first, err := r.First()
 	if err != nil {
@@ -120,6 +122,7 @@ func (r *Reader) Values(height uint64, paths []ledger.Path) ([]ledger.Value, err
 				if err != nil {
 					return fmt.Errorf("could not retrieve payload (path: %x): %w", path, err)
 				}
+
 				values[i] = payload.Value()
 				return nil
 			})
@@ -127,6 +130,10 @@ func (r *Reader) Values(height uint64, paths []ledger.Path) ([]ledger.Value, err
 		})
 	}
 	err = g.Wait()
+
+	// Temporary log line to compare execution times of individual GetRegisterValues calls
+	fmt.Printf("index reader values processing time: %s\n", time.Since(t))
+
 	return values, err
 }
 

--- a/service/index/reader.go
+++ b/service/index/reader.go
@@ -136,7 +136,7 @@ func (r *Reader) Values(height uint64, paths []ledger.Path) ([]ledger.Value, err
 	err = g.Wait()
 
 	// Temporary log line to compare execution times of individual GetRegisterValues calls
-	fmt.Printf("index reader values processing time: %s\n", time.Since(t))
+	r.log.Info().Dur("duration", time.Since(t)).Int("paths", len(paths)).Uint64("height", height).Msg("index reader values fetched from db")
 
 	return values, err
 }

--- a/service/index/reader.go
+++ b/service/index/reader.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dgraph-io/badger/v2"
@@ -35,6 +37,7 @@ const ConcurrentPathReadLimit int = 128
 // Reader implements the `index.Reader` interface on top of the DPS server's
 // Badger database index.
 type Reader struct {
+	log zerolog.Logger
 	db  *badger.DB
 	lib archive.ReadLibrary
 }
@@ -42,9 +45,10 @@ type Reader struct {
 // NewReader creates a new index reader, using the given database as the
 // underlying state repository. It is recommended to provide a read-only Badger
 // database.
-func NewReader(db *badger.DB, lib archive.ReadLibrary) *Reader {
+func NewReader(log zerolog.Logger, db *badger.DB, lib archive.ReadLibrary) *Reader {
 
 	r := Reader{
+		log: log.With().Str("component", "index_reader").Logger(),
 		db:  db,
 		lib: lib,
 	}


### PR DESCRIPTION
## Goal of this PR
Include extra log line to keep track of badgerdb read times when executing `GetRegisterValues` function.