### PR TITLE
add follower log level

### DIFF
--- a/cmd/flow-archive-live/main.go
+++ b/cmd/flow-archive-live/main.go
@@ -74,16 +74,17 @@ func run() int {
 
 	// Command line parameter initialization.
 	var (
-		flagAddress     string
-		flagBootstrap   string
-		flagBucket      string
-		flagCheckpoint  string
-		flagData        string
-		flagIndex       string
-		flagLevel       string
-		flagMetricsAddr string
-		flagProfiling   string
-		flagSkip        bool
+		flagAddress          string
+		flagBootstrap        string
+		flagBucket           string
+		flagCheckpoint       string
+		flagData             string
+		flagIndex            string
+		flagLevel            string
+		flagFollowerLogLevel string
+		flagMetricsAddr      string
+		flagProfiling        string
+		flagSkip             bool
 
 		flagFlushInterval time.Duration
 		flagSeedAddress   string
@@ -98,6 +99,7 @@ func run() int {
 	pflag.StringVarP(&flagData, "data", "d", "data", "path to database directory for protocol data")
 	pflag.StringVarP(&flagIndex, "index", "i", "index", "path to database directory for state index")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
+	pflag.StringVarP(&flagFollowerLogLevel, "follower-level", "l", "warn", "log output level for follower engine")
 	pflag.StringVarP(&flagMetricsAddr, "metrics", "m", "", "address on which to expose metrics (no metrics are exposed when left empty)")
 	pflag.StringVarP(&flagProfiling, "profiler-address", "p", "", "address for net/http/pprof profiler (profiler is disabled if left empty)")
 	pflag.BoolVarP(&flagSkip, "skip", "s", false, "skip indexing of execution state ledger registers")
@@ -225,7 +227,7 @@ func run() int {
 		seedNodes,
 		unstaked.WithBootstrapDir(flagBootstrap),
 		unstaked.WithDB(protocolDB),
-		unstaked.WithLogLevel(flagLevel),
+		unstaked.WithLogLevel(flagFollowerLogLevel),
 	)
 	if err != nil {
 		log.Error().Err(err).Str("bucket", flagBucket).Msg("could not create consensus follower")


### PR DESCRIPTION
## Goal of this PR

The follower engine produces lots of logs for each block, such as: `processing block proposal`, `forwarding block proposal to hotstuff`, which isn't useful for RN. 
RN only cares about block finalization, and we have log for that already. 
So this PR uses a separate flag `follower-level` to specify the log level for follower engine, the default would be warning level, in order to ignore those un-useful INFO level logs.
```


{"level":"info","node_role":"consensus_follower","node_id":"6cae4658e81879243840de72684e4655c8a1ea88ed69d1449d3ca950a0229da9","engine":"follower","chain_id":"flow-testnet","block_height":93064432,"block_view":590472,"block_id":"bce86c2dc03d37157c576a6309ec66d159dfd195cff1a09e1897b5735a625745","parent_id":"d08a40de202fdc1624801e39fea193eaa2bbb2858f6de632da95a306ecc3c361","payload_hash":"d9b69ffb3b6fe2d8ef257886ff4ba66ba41d874dad18a321d653fbb6b41e6d2e","timestamp":"2023-01-29T13:29:31.481861603Z","proposer":"732a11d1ac6d67a849485ed3e9f4b1d14ed9ee3c2b30a0b7d086ddd1df1186dd","time":"2023-04-05T23:59:45.373300224Z","message":"processing block proposal"} |  

{"level":"info","node_role":"consensus_follower","node_id":"6cae4658e81879243840de72684e4655c8a1ea88ed69d1449d3ca950a0229da9","engine":"follower","chain_id":"flow-testnet","block_height":93064431,"block_view":590471,"block_id":"d08a40de202fdc1624801e39fea193eaa2bbb2858f6de632da95a306ecc3c361","parent_id":"941f3a947f828e54ef51297b74ce48b785fe6185aa48044fa9228a3c04453335","payload_hash":"5d93a003af5b0731084be3a1b00917c61363e587e82715b1b1ffae54af4ab564","timestamp":"2023-01-29T13:29:30.623390103Z","proposer":"7d1b97cfb8c56fd23d041a7e6fe99a05b937d42182b7edb1babda0e7409c6ab4","time":"2023-04-05T23:59:45.373262898Z","message":"forwarding block proposal to hotstuff"}
```