### PR TITLE
go: bump go 1.18 -> 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,25 +34,6 @@ jobs:
       - name: Print Go version
         run: go version
 
-      # The protobuf steps uses the official instructions to install the
-      # pre-compiled binary, see:
-      # https://grpc.io/docs/protoc-installation/#install-pre-compiled-binaries-any-os
-      - name: Install Protobuf compiler
-        run: |
-          PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-          curl -LO $PB_REL/download/v21.8/protoc-21.8-linux-x86_64.zip
-          unzip protoc-21.8-linux-x86_64.zip -d $HOME/.local
-          export PATH="$PATH:$HOME/.local/bin"
-          git clean -fd
-
-      # In order to be able to generate the protocol buffer and GRPC files, we
-      # need to install the related Go modules.
-      - name: Install Protobuf dependencies
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
-          go install github.com/srikrsna/protoc-gen-gotag@v0.6.2
-
       # In order to be able to build with flow-go and the relic tag, we need to
       # run its go generate target.
       - name: Make Flow Go's crypto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Cache Go modules
         uses: actions/cache@v2
@@ -107,7 +107,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Cache Go modules
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Cache Go modules
         uses: actions/cache@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.18-buster AS build-setup
+FROM golang:1.19-buster AS build-setup
 
 RUN apt-get update \
- && apt-get -y install cmake zip sudo git
+    && apt-get -y install cmake zip sudo git
 
 RUN mkdir /archive
 WORKDIR /archive

--- a/README.md
+++ b/README.md
@@ -54,10 +54,7 @@ Please note that it is also required to make sure that your `GOPATH` is exported
 
 If you want to make changes to the GRPC API, the following dependencies are required as well.
 
-* [`protoc`](https://grpc.io/docs/protoc-installation/) version `3.17.3`
-* `go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26`
-* `go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1`
-* `go install github.com/srikrsna/protoc-gen-gotag@v0.6.2`
+* [`buf`](https://github.com/bufbuild/buf)
 
 Once they are installed, you can run `go generate ./...` from the root of this repository to update the generated protobuf files.
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ There are also additional API layers that can be run on top of the DPS API:
 * [Snapshots](./docs/snapshots.md)
 
 ## Dependencies
-
-Go `v1.16` or higher is required to compile `flow-dps`.
 Only Linux amd64 builds are supported, because of the dependency to the [`flow-go/crypto`](https://github.com/onflow/flow-go/tree/master/crypto) package.
 Please note that it is also required to make sure that your `GOPATH` is exported in your environment in order to generate the DPS API.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -109,10 +109,7 @@ Please note that it is also required to make sure that your `GOPATH` is exported
 
 If you want to make changes to the GRPC API, the following dependencies are required as well.
 
-* [`protoc`](https://grpc.io/docs/protoc-installation/) version `3.17.3`
-* `go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26`
-* `go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1`
-* `go install github.com/srikrsna/protoc-gen-gotag@v0.6.2`
+* [`buf`](https://github.com/bufbuild/buf)
 
 Once they are installed, you can run `go generate ./...` from the root of this repository to update the generated protobuf files.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/flow-archive
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/storage v1.28.1


### PR DESCRIPTION
Bump golang to 1.19[1] -- this is not a library so there is no benefit in staying on the older go version.


ref: https://github.com/onflow/flow-archive/issues/99

[1] 1.20 is not yet supported by flow-go, due to quic dependency: https://github.com/onflow/flow-go/pull/3909