### PR TITLE
LICENSE: remove Opakt as copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,8 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Optakt Labs OÜ
-   Copyright 2022 Dapper Labs
+   Copyright 2021-2023 Dapper Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/api/protobuf/api.proto
+++ b/api/protobuf/api.proto
@@ -1,17 +1,3 @@
-// Copyright 2021 Optakt Labs OÜ
-//
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not
-// use this file except in compliance with the License. You may obtain a copy of
-// the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations under
-// the License.
-
 syntax = "proto3";
 
 import "validate/validate.proto";


### PR DESCRIPTION
Legal asked to remove Optakt as copyright holder.

ref: https://dapperlabs.slack.com/archives/C02FFE3JCTA/p1683240761839249