### PR TITLE
tests: enable race detector in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,12 @@ jobs:
       # This check runs all unit tests with verbose output and ensures that all
       # of the tests pass successfully.
       - name: Verify unit tests
-        run: go test -tags relic -v ./...
+        run: go test -race -tags relic -v ./...
 
       # This check runs all integration tests with verbose output and ensures
       # that they pass successfully.
       - name: Verify integration tests
-        run: go test -v -tags="relic integration" ./...
+        run: go test -v -race -tags="relic integration" ./...
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/service/access/server_internal_test.go
+++ b/service/access/server_internal_test.go
@@ -1057,7 +1057,7 @@ func TestServer_ExecuteScriptAtBlockHeight(t *testing.T) {
 			Script:      mocks.GenericBytes,
 			Arguments:   [][]byte{cadenceValueBytes},
 		}
-		_, err = s.ExecuteScriptAtBlockHeight(context.Background(), req)
+		_, err := s.ExecuteScriptAtBlockHeight(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -1123,7 +1123,7 @@ func TestServer_ExecuteScriptAtBlockID(t *testing.T) {
 			Script:    mocks.GenericBytes,
 			Arguments: [][]byte{cadenceValueBytes},
 		}
-		_, err = s.ExecuteScriptAtBlockID(context.Background(), req)
+		_, err := s.ExecuteScriptAtBlockID(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -1144,7 +1144,7 @@ func TestServer_ExecuteScriptAtBlockID(t *testing.T) {
 			Script:    mocks.GenericBytes,
 			Arguments: [][]byte{cadenceValueBytes},
 		}
-		_, err = s.ExecuteScriptAtBlockID(context.Background(), req)
+		_, err := s.ExecuteScriptAtBlockID(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -1199,7 +1199,7 @@ func TestServer_ExecuteScriptAtLatestBlock(t *testing.T) {
 			Script:    mocks.GenericBytes,
 			Arguments: [][]byte{cadenceValueBytes},
 		}
-		_, err = s.ExecuteScriptAtLatestBlock(context.Background(), req)
+		_, err := s.ExecuteScriptAtLatestBlock(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -1219,7 +1219,7 @@ func TestServer_ExecuteScriptAtLatestBlock(t *testing.T) {
 			Script:    mocks.GenericBytes,
 			Arguments: [][]byte{cadenceValueBytes},
 		}
-		_, err = s.ExecuteScriptAtLatestBlock(context.Background(), req)
+		_, err := s.ExecuteScriptAtLatestBlock(context.Background(), req)
 
 		assert.Error(t, err)
 	})

--- a/service/storage/operations_integration_test.go
+++ b/service/storage/operations_integration_test.go
@@ -117,7 +117,7 @@ func TestLibrary(t *testing.T) {
 			t.Parallel()
 
 			var got []flow.Event
-			err = db.View(lib.RetrieveEvents(mocks.GenericHeight, mocks.GenericEventTypes(1), &got))
+			err := db.View(lib.RetrieveEvents(mocks.GenericHeight, mocks.GenericEventTypes(1), &got))
 
 			require.NoError(t, err)
 			assert.ElementsMatch(t, events1, got)
@@ -127,7 +127,7 @@ func TestLibrary(t *testing.T) {
 			t.Parallel()
 
 			var got []flow.Event
-			err = db.View(lib.RetrieveEvents(mocks.GenericHeight, []flow.EventType{}, &got))
+			err := db.View(lib.RetrieveEvents(mocks.GenericHeight, []flow.EventType{}, &got))
 
 			require.NoError(t, err)
 			assert.ElementsMatch(t, allEvents, got)
@@ -137,7 +137,7 @@ func TestLibrary(t *testing.T) {
 			t.Parallel()
 
 			var got []flow.Event
-			err = db.View(lib.RetrieveEvents(mocks.GenericHeight, mocks.GenericEventTypes(4), &got))
+			err := db.View(lib.RetrieveEvents(mocks.GenericHeight, mocks.GenericEventTypes(4), &got))
 
 			require.NoError(t, err)
 			assert.ElementsMatch(t, allEvents, got)
@@ -147,7 +147,7 @@ func TestLibrary(t *testing.T) {
 			t.Parallel()
 
 			var got []flow.Event
-			err = db.View(lib.RetrieveEvents(mocks.GenericHeight, []flow.EventType{mocks.GenericEventType(2)}, &got))
+			err := db.View(lib.RetrieveEvents(mocks.GenericHeight, []flow.EventType{mocks.GenericEventType(2)}, &got))
 
 			require.NoError(t, err)
 			assert.Empty(t, got)


### PR DESCRIPTION
Tested with:
```
$ go test -race -count 10 -tags relic,integration ./...
```