### PR TITLE
storage2: copy iterator value before close

### DIFF
--- a/service/storage2/payload/payload.go
+++ b/service/storage2/payload/payload.go
@@ -65,6 +65,7 @@ func (s *payloadStorage) GetPayload(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get value: %w", err)
 	}
+	// preventing caller from modifying the iterator's value slices
 	valueCopy := make([]byte, len(binaryValue))
 	copy(valueCopy, binaryValue)
 

--- a/service/storage2/payload/payload.go
+++ b/service/storage2/payload/payload.go
@@ -65,8 +65,10 @@ func (s *payloadStorage) GetPayload(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get value: %w", err)
 	}
+	valueCopy := make([]byte, len(binaryValue))
+	copy(valueCopy, binaryValue)
 
-	return binaryValue, nil
+	return valueCopy, nil
 }
 
 // BatchSetPayload sets the given entries in a batch.


### PR DESCRIPTION
Otherwise next iteration can potentially corrupt the data:

> // Value returns the value of the current key/value pair, or nil if done. The
> // caller should not modify the contents of the returned slice, and its
> // contents may change on the next call to Next.