### PR TITLE
storage2: move MVCCComparer to config

### DIFF
--- a/service/storage2/config/comparer.go
+++ b/service/storage2/config/comparer.go
@@ -1,15 +1,20 @@
-package payload
+package config
 
 import "github.com/cockroachdb/pebble"
 
-// newMVCCComparer creates a new comparer with a
+const (
+	// Size of the block height encoded in the key.
+	HeightSuffixLen = 8
+)
+
+// NewMVCCComparer creates a new comparer with a
 // custom Split function that separates the height from the rest of the key.
 //
 // This is needed for SeekPrefixGE to work.
-func newMVCCComparer() *pebble.Comparer {
+func NewMVCCComparer() *pebble.Comparer {
 	comparer := *pebble.DefaultComparer
 	comparer.Split = func(a []byte) int {
-		return len(a) - heightSuffixLen
+		return len(a) - HeightSuffixLen
 	}
 	comparer.Name = "flow.MVCCComparer"
 

--- a/service/storage2/config/comparer_test.go
+++ b/service/storage2/config/comparer_test.go
@@ -1,4 +1,4 @@
-package payload
+package config
 
 import (
 	"testing"
@@ -6,18 +6,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_newMVCCComparer_Split(t *testing.T) {
+func Test_NewMVCCComparer_Split(t *testing.T) {
 	t.Parallel()
 
-	comparer := newMVCCComparer()
+	comparer := NewMVCCComparer()
 
 	tests := []struct {
 		name string
 		arg  []byte
 		want int
 	}{
-		{name: "nil", arg: nil, want: -8},
-		{name: "empty", arg: []byte(""), want: -8},
+		{name: "nil", arg: nil, want: -HeightSuffixLen},
+		{name: "empty", arg: []byte(""), want: -HeightSuffixLen},
 		{name: "edge0", arg: []byte("1234567"), want: -1},
 		{name: "edge1", arg: []byte("12345678"), want: 0},
 		{name: "edge2", arg: []byte("123456789"), want: 1},

--- a/service/storage2/payload/lookup.go
+++ b/service/storage2/payload/lookup.go
@@ -3,6 +3,7 @@ package payload
 import (
 	"encoding/binary"
 
+	"github.com/onflow/flow-archive/service/storage2/config"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -13,7 +14,7 @@ type lookupKey struct {
 
 func newLookupKey(height uint64, reg flow.RegisterID) *lookupKey {
 	key := lookupKey{
-		encoded: make([]byte, 0, len(reg.Owner)+1+len(reg.Key)+1+heightSuffixLen),
+		encoded: make([]byte, 0, len(reg.Owner)+1+len(reg.Key)+1+config.HeightSuffixLen),
 	}
 
 	// The lookup key used to find most recent value for a register.

--- a/service/storage2/payload/payload.go
+++ b/service/storage2/payload/payload.go
@@ -9,11 +9,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-const (
-	// Size of the block height encoded in the key.
-	heightSuffixLen = 8
-)
-
 type Storage struct {
 	db *pebble.DB
 }
@@ -24,7 +19,7 @@ type Storage struct {
 // It needs to access the last available payload with height less or equal to the requested height.
 // This means all point-lookups are range scans.
 func NewStorage(dbPath string, cache *pebble.Cache) (*Storage, error) {
-	opts := config.DefaultPebbleOptions(cache, newMVCCComparer())
+	opts := config.DefaultPebbleOptions(cache, config.NewMVCCComparer())
 	db, err := pebble.Open(dbPath, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open db: %w", err)


### PR DESCRIPTION
this code would be reused for other mvcc-based databases. no functional changes.