### PR TITLE
Add status codes for Script exec API

### DIFF
--- a/service/access/server.go
+++ b/service/access/server.go
@@ -413,7 +413,8 @@ func (s *Server) GetAccountAtBlockHeight(_ context.Context, in *access.GetAccoun
 func (s *Server) ExecuteScriptAtLatestBlock(ctx context.Context, in *access.ExecuteScriptAtLatestBlockRequest) (*access.ExecuteScriptResponse, error) {
 	height, err := s.index.Last()
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not get last height: %w", err)
+		err = fmt.Errorf("could not get last height: %w", err)
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	req := &access.ExecuteScriptAtBlockHeightRequest{
@@ -431,7 +432,8 @@ func (s *Server) ExecuteScriptAtBlockID(ctx context.Context, in *access.ExecuteS
 	blockID := flow.HashToID(in.BlockId)
 	height, err := s.index.HeightForBlock(blockID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not get height for block ID %x: %w", blockID, err)
+		err = fmt.Errorf("could not get height for block ID %x: %w", blockID, err)
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	req := &access.ExecuteScriptAtBlockHeightRequest{
@@ -450,7 +452,8 @@ func (s *Server) ExecuteScriptAtBlockHeight(_ context.Context, in *access.Execut
 	for _, arg := range in.Arguments {
 		val, err := json.Decode(nil, arg)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "could not decode script argument: %w", err)
+			err = fmt.Errorf("could not decode script argument: %w", err)
+			return nil, status.Error(codes.Internal, err.Error())
 		}
 
 		args = append(args, val)
@@ -458,12 +461,14 @@ func (s *Server) ExecuteScriptAtBlockHeight(_ context.Context, in *access.Execut
 
 	value, err := s.invoker.Script(in.BlockHeight, in.Script, args)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "could not execute script: %w", err)
+		err = fmt.Errorf("could not execute script: %w", err)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	result, err := json.Encode(value)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not encode script result: %w", err)
+		err = fmt.Errorf("could not encode script result: %w", err)
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	resp := access.ExecuteScriptResponse{

--- a/service/access/server.go
+++ b/service/access/server.go
@@ -413,8 +413,7 @@ func (s *Server) GetAccountAtBlockHeight(_ context.Context, in *access.GetAccoun
 func (s *Server) ExecuteScriptAtLatestBlock(ctx context.Context, in *access.ExecuteScriptAtLatestBlockRequest) (*access.ExecuteScriptResponse, error) {
 	height, err := s.index.Last()
 	if err != nil {
-		err = fmt.Errorf("could not get last height: %w", err)
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal, "could not get last height: %v", err)
 	}
 
 	req := &access.ExecuteScriptAtBlockHeightRequest{
@@ -432,8 +431,7 @@ func (s *Server) ExecuteScriptAtBlockID(ctx context.Context, in *access.ExecuteS
 	blockID := flow.HashToID(in.BlockId)
 	height, err := s.index.HeightForBlock(blockID)
 	if err != nil {
-		err = fmt.Errorf("could not get height for block ID %x: %w", blockID, err)
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal, "could not get height for block ID %x: %v", blockID, err)
 	}
 
 	req := &access.ExecuteScriptAtBlockHeightRequest{
@@ -452,8 +450,7 @@ func (s *Server) ExecuteScriptAtBlockHeight(_ context.Context, in *access.Execut
 	for _, arg := range in.Arguments {
 		val, err := json.Decode(nil, arg)
 		if err != nil {
-			err = fmt.Errorf("could not decode script argument: %w", err)
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, status.Errorf(codes.Internal, "could not decode script argument: %v", err)
 		}
 
 		args = append(args, val)
@@ -461,14 +458,12 @@ func (s *Server) ExecuteScriptAtBlockHeight(_ context.Context, in *access.Execut
 
 	value, err := s.invoker.Script(in.BlockHeight, in.Script, args)
 	if err != nil {
-		err = fmt.Errorf("could not execute script: %w", err)
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "could not execute script: %v", err)
 	}
 
 	result, err := json.Encode(value)
 	if err != nil {
-		err = fmt.Errorf("could not encode script result: %w", err)
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal, "could not encode script result: %v", err)
 	}
 
 	resp := access.ExecuteScriptResponse{

--- a/service/access/server.go
+++ b/service/access/server.go
@@ -431,7 +431,7 @@ func (s *Server) ExecuteScriptAtBlockID(ctx context.Context, in *access.ExecuteS
 	blockID := flow.HashToID(in.BlockId)
 	height, err := s.index.HeightForBlock(blockID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not get height for block ID %x: %v", blockID, err)
+		return nil, status.Errorf(codes.NotFound, "could not get height for block ID %x: %v", blockID, err)
 	}
 
 	req := &access.ExecuteScriptAtBlockHeightRequest{
@@ -450,7 +450,7 @@ func (s *Server) ExecuteScriptAtBlockHeight(_ context.Context, in *access.Execut
 	for _, arg := range in.Arguments {
 		val, err := json.Decode(nil, arg)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "could not decode script argument: %v", err)
+			return nil, status.Errorf(codes.InvalidArgument, "could not decode script argument: %v", err)
 		}
 
 		args = append(args, val)

--- a/service/access/server_internal_test.go
+++ b/service/access/server_internal_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
@@ -1126,6 +1128,7 @@ func TestServer_ExecuteScriptAtBlockID(t *testing.T) {
 		_, err := s.ExecuteScriptAtBlockID(context.Background(), req)
 
 		assert.Error(t, err)
+		assert.Equal(t, status.Code(err), codes.Internal)
 	})
 
 	t.Run("handles invoker failure", func(t *testing.T) {
@@ -1147,6 +1150,7 @@ func TestServer_ExecuteScriptAtBlockID(t *testing.T) {
 		_, err := s.ExecuteScriptAtBlockID(context.Background(), req)
 
 		assert.Error(t, err)
+		assert.Equal(t, status.Code(err), codes.InvalidArgument)
 	})
 }
 
@@ -1202,6 +1206,7 @@ func TestServer_ExecuteScriptAtLatestBlock(t *testing.T) {
 		_, err := s.ExecuteScriptAtLatestBlock(context.Background(), req)
 
 		assert.Error(t, err)
+		assert.Equal(t, status.Code(err), codes.Internal)
 	})
 
 	t.Run("handles invoker failure", func(t *testing.T) {
@@ -1222,6 +1227,7 @@ func TestServer_ExecuteScriptAtLatestBlock(t *testing.T) {
 		_, err := s.ExecuteScriptAtLatestBlock(context.Background(), req)
 
 		assert.Error(t, err)
+		assert.Equal(t, status.Code(err), codes.InvalidArgument)
 	})
 }
 

--- a/service/access/server_internal_test.go
+++ b/service/access/server_internal_test.go
@@ -1128,7 +1128,7 @@ func TestServer_ExecuteScriptAtBlockID(t *testing.T) {
 		_, err := s.ExecuteScriptAtBlockID(context.Background(), req)
 
 		assert.Error(t, err)
-		assert.Equal(t, status.Code(err), codes.Internal)
+		assert.Equal(t, status.Code(err), codes.NotFound)
 	})
 
 	t.Run("handles invoker failure", func(t *testing.T) {


### PR DESCRIPTION
## Goal of this PR
Adds distinction between `Internal` errors like type conversions for cadence values and `InvalidArgument` errors that are errors in the script, not the execution runtime or Archive node

fixes #97 