### PR TITLE
Decode lookup key

### DIFF
--- a/service/storage2/payload/lookup.go
+++ b/service/storage2/payload/lookup.go
@@ -40,11 +40,12 @@ func newLookupKey(height uint64, reg flow.RegisterID) *lookupKey {
 
 // lookupKeyToRegisterID takes a lookup key and decode it into height and RegisterID
 func lookupKeyToRegisterID(lookupKey []byte) (uint64, flow.RegisterID, error) {
-       const minLookupKeyLen = 2 + config.HeightSuffixLen
-       if len(lookupKey) < minLookupKeyLen {   
-                return 0, flow.RegiterID{}, fmt.Errorf("invalid lookup key format: expected >= %d bytes, got %d bytes", minLookupKeyLen, len(lookupKey))
-       }
-       
+	const minLookupKeyLen = 2 + config.HeightSuffixLen
+	if len(lookupKey) < minLookupKeyLen {
+		return 0, flow.RegisterID{}, fmt.Errorf("invalid lookup key format: expected >= %d bytes, got %d bytes",
+			minLookupKeyLen, len(lookupKey))
+	}
+
 	// Find the first slash to split the lookup key and decode the owner.
 	firstSlash := bytes.IndexByte(lookupKey, '/')
 	if firstSlash == -1 {
@@ -53,22 +54,23 @@ func lookupKeyToRegisterID(lookupKey []byte) (uint64, flow.RegisterID, error) {
 
 	owner := string(lookupKey[:firstSlash])
 
-        // Find the last slash to split encoded height.
-        lastSlashPos := bytes.LastIndexByte(lookupKey, '/')
-        if lastSlashPos == firstSlash {
-		return 0, flow.RegisterID{}, fmt.Errorf("invalid lookup key format: expected 2 separators, got 1 separator")        
-        }
-        encodedHeightPos := lastSlashPos + 1
-        if len(lookupKey) - encodedHeightPos !=  config.HeightSuffixLen {
-		return 0, flow.RegisterID{}, fmt.Errorf("invalid lookup key format: expected %d bytes of encoded height, got %d bytes", config.HeightSuffixLen, len(lookupKey) - encodedHeightPos)                
-        }
-        
+	// Find the last slash to split encoded height.
+	lastSlashPos := bytes.LastIndexByte(lookupKey, '/')
+	if lastSlashPos == firstSlash {
+		return 0, flow.RegisterID{}, fmt.Errorf("invalid lookup key format: expected 2 separators, got 1 separator")
+	}
+	encodedHeightPos := lastSlashPos + 1
+	if len(lookupKey)-encodedHeightPos != config.HeightSuffixLen {
+		return 0, flow.RegisterID{},
+			fmt.Errorf("invalid lookup key format: expected %d bytes of encoded height, got %d bytes",
+				config.HeightSuffixLen, len(lookupKey)-encodedHeightPos)
+	}
+
 	// Decode height.
 	heightBytes := lookupKey[encodedHeightPos:]
 
 	oneCompliment := binary.BigEndian.Uint64(heightBytes)
 	height := ^oneCompliment
-
 
 	// Decode the remaining bytes into the key.
 	keyBytes := lookupKey[firstSlash+1 : lastSlashPos]

--- a/service/storage2/payload/lookup.go
+++ b/service/storage2/payload/lookup.go
@@ -40,6 +40,11 @@ func newLookupKey(height uint64, reg flow.RegisterID) *lookupKey {
 
 // lookupKeyToRegisterID takes a lookup key and decode it into height and RegisterID
 func lookupKeyToRegisterID(lookupKey []byte) (uint64, flow.RegisterID, error) {
+       const minLookupKeyLen = 2 + config.HeightSuffixLen
+       if len(lookupKey) < minLookupKeyLen {   
+                return 0, flow.RegiterID{}, fmt.Errorf("invalid lookup key format: expected >= %d bytes, got %d bytes", minLookupKeyLen, len(lookupKey))
+       }
+       
 	// Find the first slash to split the lookup key and decode the owner.
 	firstSlash := bytes.IndexByte(lookupKey, '/')
 	if firstSlash == -1 {
@@ -48,24 +53,25 @@ func lookupKeyToRegisterID(lookupKey []byte) (uint64, flow.RegisterID, error) {
 
 	owner := string(lookupKey[:firstSlash])
 
-	// Find the last 8 bytes to decode the height.
-	heightBytes := lookupKey[len(lookupKey)-8:]
-	if len(heightBytes) != 8 {
-		return 0, flow.RegisterID{}, fmt.Errorf("invalid lookup key format: cannot find height")
-	}
+        // Find the last slash to split encoded height.
+        lastSlashPos := bytes.LastIndexByte(lookupKey, '/')
+        if lastSlashPos == firstSlash {
+		return 0, flow.RegisterID{}, fmt.Errorf("invalid lookup key format: expected 2 separators, got 1 separator")        
+        }
+        encodedHeightPos := lastSlashPos + 1
+        if len(lookupKey) - encodedHeightPos !=  config.HeightSuffixLen {
+		return 0, flow.RegisterID{}, fmt.Errorf("invalid lookup key format: expected %d bytes of encoded height, got %d bytes", config.HeightSuffixLen, len(lookupKey) - encodedHeightPos)                
+        }
+        
+	// Decode height.
+	heightBytes := lookupKey[encodedHeightPos:]
 
 	oneCompliment := binary.BigEndian.Uint64(heightBytes)
 	height := ^oneCompliment
 
-	// Find the position of the second slash from the end.
-	secondSlashPos := len(lookupKey) - 9
-	// Validate the presence of the second slash.
-	if secondSlashPos <= firstSlash {
-		return 0, flow.RegisterID{}, fmt.Errorf("invalid lookup key format: second slash not found")
-	}
 
 	// Decode the remaining bytes into the key.
-	keyBytes := lookupKey[firstSlash+1 : secondSlashPos]
+	keyBytes := lookupKey[firstSlash+1 : lastSlashPos]
 	key := string(keyBytes)
 
 	regID := flow.RegisterID{Owner: owner, Key: key}

--- a/service/storage2/payload/lookup_test.go
+++ b/service/storage2/payload/lookup_test.go
@@ -36,28 +36,57 @@ func Test_lookupKey_Bytes(t *testing.T) {
 
 func Test_decodeKey_Bytes(t *testing.T) {
 	height := uint64(10)
-	owner := "owneraddress"
-	key := "public/storage"
 
-	lookupKey := newLookupKey(height, flow.RegisterID{Owner: owner, Key: key})
-	decodedHeight, decodedReg, err := lookupKeyToRegisterID(lookupKey.Bytes())
-	require.NoError(t, err)
+	cases := []struct {
+		owner string
+		key   string
+	}{
+		{owner: "owneraddress", key: "public/storage/hasslash-in-key"},
+		{owner: "owneraddress", key: ""},
+		{owner: "", key: "somekey"},
+		{owner: "", key: ""},
+	}
 
-	require.Equal(t, height, decodedHeight)
-	require.Equal(t, owner, decodedReg.Owner)
-	require.Equal(t, key, decodedReg.Key)
+	for _, c := range cases {
+		owner, key := c.owner, c.key
+
+		lookupKey := newLookupKey(height, flow.RegisterID{Owner: owner, Key: key})
+		decodedHeight, decodedReg, err := lookupKeyToRegisterID(lookupKey.Bytes())
+		require.NoError(t, err)
+
+		require.Equal(t, height, decodedHeight)
+		require.Equal(t, owner, decodedReg.Owner)
+		require.Equal(t, key, decodedReg.Key)
+	}
 }
 
-func Test_decodeKey_emptykey(t *testing.T) {
-	height := uint64(10)
-	owner := "owneraddress"
-	key := ""
+func Test_decodeKey_fail(t *testing.T) {
+	var err error
+	// less than min length (10)
+	_, _, err = lookupKeyToRegisterID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9})
+	require.Contains(t, err.Error(), "bytes")
 
-	lookupKey := newLookupKey(height, flow.RegisterID{Owner: owner, Key: key})
-	decodedHeight, decodedReg, err := lookupKeyToRegisterID(lookupKey.Bytes())
+	// missing slash
+	_, _, err = lookupKeyToRegisterID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+	require.Contains(t, err.Error(), "slash")
+
+	// missing second slash
+	_, _, err = lookupKeyToRegisterID([]byte{1, 2, 3, '/', 5, 6, 7, 8, 9, 10})
+	require.Contains(t, err.Error(), "separator")
+
+	// invalid height
+	_, _, err = lookupKeyToRegisterID([]byte{1, 2, 3, '/', 5, 6, 7, 8, '/', 10})
+	require.Contains(t, err.Error(), "height")
+
+	// invalid height
+	_, _, err = lookupKeyToRegisterID([]byte{1, 2, 3, '/', 5, '/', 7, 8, 9, 10})
+	require.Contains(t, err.Error(), "height")
+
+	// invalid height
+	_, _, err = lookupKeyToRegisterID([]byte{1, 2, 3, '/', 5, '/', 7, 8, 9, 10, 11, 12, 13})
+	require.Contains(t, err.Error(), "height")
+
+	// valid height
+	_, _, err = lookupKeyToRegisterID([]byte{1, 2, 3, '/', 5, '/', 7, 8, 9, 10, 11, 12, 13, 14})
 	require.NoError(t, err)
-
-	require.Equal(t, height, decodedHeight)
-	require.Equal(t, owner, decodedReg.Owner)
-	require.Equal(t, key, decodedReg.Key)
 }

--- a/service/storage2/payload/lookup_test.go
+++ b/service/storage2/payload/lookup_test.go
@@ -25,4 +25,11 @@ func Test_lookupKey_Bytes(t *testing.T) {
 
 	// Test everything together
 	require.Equal(t, []byte("owner/key/\xff\xff\xff\xff\xff\xff\xfc\xf6"), key.Bytes())
+
+	decodedHeight, decodedReg, err := lookupKeyToRegisterID(key.encoded)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedHeight, decodedHeight)
+	require.Equal(t, "owner", decodedReg.Owner)
+	require.Equal(t, "key", decodedReg.Key)
 }

--- a/service/storage2/payload/lookup_test.go
+++ b/service/storage2/payload/lookup_test.go
@@ -33,3 +33,31 @@ func Test_lookupKey_Bytes(t *testing.T) {
 	require.Equal(t, "owner", decodedReg.Owner)
 	require.Equal(t, "key", decodedReg.Key)
 }
+
+func Test_decodeKey_Bytes(t *testing.T) {
+	height := uint64(10)
+	owner := "owneraddress"
+	key := "public/storage"
+
+	lookupKey := newLookupKey(height, flow.RegisterID{Owner: owner, Key: key})
+	decodedHeight, decodedReg, err := lookupKeyToRegisterID(lookupKey.Bytes())
+	require.NoError(t, err)
+
+	require.Equal(t, height, decodedHeight)
+	require.Equal(t, owner, decodedReg.Owner)
+	require.Equal(t, key, decodedReg.Key)
+}
+
+func Test_decodeKey_emptykey(t *testing.T) {
+	height := uint64(10)
+	owner := "owneraddress"
+	key := ""
+
+	lookupKey := newLookupKey(height, flow.RegisterID{Owner: owner, Key: key})
+	decodedHeight, decodedReg, err := lookupKeyToRegisterID(lookupKey.Bytes())
+	require.NoError(t, err)
+
+	require.Equal(t, height, decodedHeight)
+	require.Equal(t, owner, decodedReg.Owner)
+	require.Equal(t, key, decodedReg.Key)
+}

--- a/service/storage2/payload/payload.go
+++ b/service/storage2/payload/payload.go
@@ -88,6 +88,23 @@ func (s *Storage) BatchSetPayload(
 	return nil
 }
 
+func (s *Storage) PruneByHeight(height uint64) (int, error) {
+	pruned := 0
+
+	iter := s.db.NewIter(&pebble.IterOptions{
+		UseL6Filters: true,
+	})
+	defer iter.Close()
+
+	ok := iter.SeekPrefixGE([]byte{})
+	if !ok {
+		return pruned, nil
+	}
+
+	_ = iter.Key()
+	return pruned, nil
+}
+
 // Close closes the storage.
 func (s *Storage) Close() error {
 	return s.db.Close()

--- a/service/storage2/payload/payload.go
+++ b/service/storage2/payload/payload.go
@@ -88,23 +88,6 @@ func (s *Storage) BatchSetPayload(
 	return nil
 }
 
-func (s *Storage) PruneByHeight(height uint64) (int, error) {
-	pruned := 0
-
-	iter := s.db.NewIter(&pebble.IterOptions{
-		UseL6Filters: true,
-	})
-	defer iter.Close()
-
-	ok := iter.SeekPrefixGE([]byte{})
-	if !ok {
-		return pruned, nil
-	}
-
-	_ = iter.Key()
-	return pruned, nil
-}
-
 // Close closes the storage.
 func (s *Storage) Close() error {
 	return s.db.Close()


### PR DESCRIPTION
## Goal of this PR

This PR adds a lookupKeyToRegisterID function to decode the lookup key that is encoded by the newLookupKey function