### PR TITLE
Invoker refactor 2

### DIFF
--- a/cmd/flow-archive-client/main.go
+++ b/cmd/flow-archive-client/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/onflow/flow-archive/codec/zbor"
 	"github.com/onflow/flow-archive/models/convert"
 	"github.com/onflow/flow-archive/service/invoker"
+	flowModel "github.com/onflow/flow-go/model/flow"
 )
 
 const (
@@ -117,7 +118,21 @@ func run() int {
 
 	// Execute the script using remote lookup and read.
 	client := archive.NewAPIClient(conn)
-	invoke, err := invoker.New(archive.IndexFromAPI(client, codec), invoker.WithCacheSize(flagCache))
+
+	read := archive.IndexFromAPI(client, codec)
+
+	chainID, err := getChainId(read)
+	if err != nil {
+		log.Error().Err(err).Msg("could not get chain id")
+		return failure
+	}
+
+	invoke, err := invoker.New(
+		read,
+		invoker.Config{
+			CacheSize: flagCache,
+			ChainID:   chainID,
+		})
 	if err != nil {
 		log.Error().Err(err).Msg("could not initialize invoker")
 		return failure
@@ -127,13 +142,25 @@ func run() int {
 		log.Error().Err(err).Msg("could not invoke script")
 		return failure
 	}
-	output, err := json.Encode(result)
-	if err != nil {
-		log.Error().Uint64("height", flagHeight).Err(err).Msg("could not encode result")
-		return failure
-	}
 
-	fmt.Println(string(output))
+	fmt.Println(string(result))
 
 	return success
+}
+
+func getChainId(read *archive.Index) (flowModel.ChainID, error) {
+	chainID := flowModel.Emulator
+
+	f, err := read.First()
+	if err != nil {
+		return chainID, err
+	}
+
+	h, err := read.Header(f)
+	if err != nil {
+		return chainID, err
+	}
+	chainID = h.ChainID
+
+	return chainID, nil
 }

--- a/cmd/flow-archive-live/main.go
+++ b/cmd/flow-archive-live/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/onflow/flow-go/crypto"
 	unstaked "github.com/onflow/flow-go/follower"
 	"github.com/onflow/flow-go/model/bootstrap"
+	flowModel "github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow/protobuf/go/flow/access"
 
 	api "github.com/onflow/flow-archive/api/archive"
@@ -386,8 +387,20 @@ func run() int {
 		server = api.NewServer(read, codec)
 	}
 
+	chainID, err := getChainId(read)
+	if err != nil {
+		log.Error().Err(err).Msg("could not get chainID")
+		return failure
+	}
+
 	log.Info().Msgf("Creating local invoker with register cache: %d", flagCache)
-	invoke, err := invoker.New(read, invoker.WithCacheSize(flagCache))
+	invoke, err := invoker.New(
+		read,
+		invoker.Config{
+			CacheSize: flagCache,
+			ChainID:   chainID,
+		},
+	)
 	if err != nil {
 		log.Error().Err(err).Msg("could not initialize script invoker")
 		return failure
@@ -510,4 +523,21 @@ func run() int {
 	}
 
 	return success
+}
+
+func getChainId(read *index.Reader) (flowModel.ChainID, error) {
+	chainID := flowModel.Emulator
+
+	f, err := read.First()
+	if err != nil {
+		return chainID, err
+	}
+
+	h, err := read.Header(f)
+	if err != nil {
+		return chainID, err
+	}
+	chainID = h.ChainID
+
+	return chainID, nil
 }

--- a/models/access/invoker.go
+++ b/models/access/invoker.go
@@ -1,7 +1,6 @@
 package access
 
 import (
-	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -9,5 +8,5 @@ import (
 // from the Flow Virtual Machine.
 type Invoker interface {
 	Account(height uint64, address flow.Address) (*flow.Account, error)
-	Script(height uint64, script []byte, parameters [][]byte) (cadence.Value, error)
+	Script(height uint64, script []byte, parameters [][]byte) ([]byte, error)
 }

--- a/service/access/server.go
+++ b/service/access/server.go
@@ -11,7 +11,6 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow-archive/models/archive"
 	conv "github.com/onflow/flow-archive/models/convert"
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
@@ -450,13 +449,8 @@ func (s *Server) ExecuteScriptAtBlockHeight(_ context.Context, in *access.Execut
 		return nil, status.Errorf(codes.InvalidArgument, "could not execute script: %v", err)
 	}
 
-	result, err := json.Encode(value)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not encode script result: %v", err)
-	}
-
 	resp := access.ExecuteScriptResponse{
-		Value: result,
+		Value: value,
 	}
 
 	return &resp, nil

--- a/service/access/server_internal_test.go
+++ b/service/access/server_internal_test.go
@@ -1021,12 +1021,12 @@ func TestServer_ExecuteScriptAtBlockHeight(t *testing.T) {
 		t.Parallel()
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.ScriptFunc = func(height uint64, script []byte, parameters [][]byte) (cadence.Value, error) {
+		invoker.ScriptFunc = func(height uint64, script []byte, parameters [][]byte) ([]byte, error) {
 			assert.Equal(t, mocks.GenericHeight, height)
 			assert.Equal(t, mocks.GenericBytes, script)
 			assert.Equal(t, [][]byte{cadenceValueBytes}, parameters)
 
-			return mocks.GenericAmount(0), nil
+			return json.MustEncode(mocks.GenericAmount(0)), nil
 		}
 
 		s := baselineServer(t)
@@ -1047,7 +1047,7 @@ func TestServer_ExecuteScriptAtBlockHeight(t *testing.T) {
 		t.Parallel()
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.ScriptFunc = func(uint64, []byte, [][]byte) (cadence.Value, error) {
+		invoker.ScriptFunc = func(uint64, []byte, [][]byte) ([]byte, error) {
 			return nil, mocks.GenericError
 		}
 
@@ -1079,12 +1079,12 @@ func TestServer_ExecuteScriptAtBlockID(t *testing.T) {
 		t.Parallel()
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.ScriptFunc = func(height uint64, script []byte, parameters [][]byte) (cadence.Value, error) {
+		invoker.ScriptFunc = func(height uint64, script []byte, parameters [][]byte) ([]byte, error) {
 			assert.Equal(t, mocks.GenericHeight, height)
 			assert.Equal(t, mocks.GenericBytes, script)
 			assert.Equal(t, [][]byte{cadenceValueBytes}, parameters)
 
-			return mocks.GenericAmount(0), nil
+			return json.MustEncode(mocks.GenericAmount(0)), nil
 		}
 
 		index := mocks.BaselineReader(t)
@@ -1135,7 +1135,7 @@ func TestServer_ExecuteScriptAtBlockID(t *testing.T) {
 		t.Parallel()
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.ScriptFunc = func(uint64, []byte, [][]byte) (cadence.Value, error) {
+		invoker.ScriptFunc = func(uint64, []byte, [][]byte) ([]byte, error) {
 			return nil, mocks.GenericError
 		}
 
@@ -1166,12 +1166,12 @@ func TestServer_ExecuteScriptAtLatestBlock(t *testing.T) {
 		t.Parallel()
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.ScriptFunc = func(height uint64, script []byte, parameters [][]byte) (cadence.Value, error) {
+		invoker.ScriptFunc = func(height uint64, script []byte, parameters [][]byte) ([]byte, error) {
 			assert.Equal(t, mocks.GenericHeight, height)
 			assert.Equal(t, mocks.GenericBytes, script)
 			assert.Equal(t, [][]byte{cadenceValueBytes}, parameters)
 
-			return mocks.GenericAmount(0), nil
+			return json.MustEncode(mocks.GenericAmount(0)), nil
 		}
 
 		s := baselineServer(t)
@@ -1213,7 +1213,7 @@ func TestServer_ExecuteScriptAtLatestBlock(t *testing.T) {
 		t.Parallel()
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.ScriptFunc = func(uint64, []byte, [][]byte) (cadence.Value, error) {
+		invoker.ScriptFunc = func(uint64, []byte, [][]byte) ([]byte, error) {
 			return nil, mocks.GenericError
 		}
 

--- a/service/invoker/blocks.go
+++ b/service/invoker/blocks.go
@@ -1,0 +1,43 @@
+package invoker
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-archive/models/archive"
+	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+var _ environment.Blocks = (*Blocks)(nil)
+
+type Blocks struct {
+	index archive.Reader
+}
+
+// ByHeightFrom implements the fvm/env/blocks interface
+func (b *Blocks) ByHeightFrom(height uint64, header *flow.Header) (*flow.Header, error) {
+
+	if header.Height == height {
+		return header, nil
+	}
+
+	if height > header.Height {
+		minHeight, err := b.index.First()
+		if err != nil {
+			return nil, fmt.Errorf("could not find first indexed height: %w", err)
+		}
+		// imitate flow-go error format
+		err = errors.NewValueErrorf(fmt.Sprint(height),
+			"requested height (%d) is not in the range(%d, %d)", height, minHeight, header.Height)
+		return nil, fmt.Errorf("cannot retrieve block parent: %w", err)
+	}
+	// find the block in storage as all of them are guaranteed to be finalized
+	return b.index.Header(height)
+}
+
+func NewBlocks(index archive.Reader) *Blocks {
+	return &Blocks{
+		index: index,
+	}
+}

--- a/service/invoker/config.go
+++ b/service/invoker/config.go
@@ -1,13 +1,23 @@
 package invoker
 
+import (
+	"github.com/onflow/flow-go/engine/execution/computation"
+	"github.com/onflow/flow-go/fvm/storage/derived"
+	"github.com/onflow/flow-go/model/flow"
+)
+
 // Config is the configuration for an invoker.
 type Config struct {
+	computation.ComputationConfig
 	CacheSize uint64
+	ChainID   flow.ChainID
 }
 
-// WithCacheSize specifies the size of the cache the invoker uses.
-func WithCacheSize(size uint64) func(*Config) {
-	return func(cfg *Config) {
-		cfg.CacheSize = size
-	}
+const DefaultCacheSize = uint64(100_000_000) // ~100 MB default size
+
+var DefaultConfig = Config{
+	CacheSize: DefaultCacheSize,
+	ComputationConfig: computation.ComputationConfig{
+		DerivedDataCacheSize: derived.DefaultDerivedDataCacheSize,
+	},
 }

--- a/service/invoker/invoker.go
+++ b/service/invoker/invoker.go
@@ -1,47 +1,39 @@
 package invoker
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dgraph-io/ristretto"
-	"github.com/onflow/cadence"
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/flow-archive/models/archive"
 	"github.com/onflow/flow-archive/util"
+	"github.com/onflow/flow-go/engine/execution/computation"
+	"github.com/onflow/flow-go/engine/execution/computation/query"
 	"github.com/onflow/flow-go/fvm"
-	"github.com/onflow/flow-go/fvm/environment"
-	"github.com/onflow/flow-go/fvm/errors"
+	reusableRuntime "github.com/onflow/flow-go/fvm/runtime"
+	"github.com/onflow/flow-go/fvm/storage/derived"
 	"github.com/onflow/flow-go/fvm/storage/snapshot"
 	"github.com/onflow/flow-go/model/flow"
-
-	"github.com/onflow/flow-archive/models/archive"
+	"github.com/onflow/flow-go/module/metrics"
 )
 
 // Invoker retrieves account information from and executes Cadence scripts against
 // the Flow virtual machine.
 type Invoker struct {
-	index archive.Reader
-	vm    fvm.VM
-	vmCtx fvm.Context
-	cache Cache
+	index         archive.Reader
+	queryExecutor *query.QueryExecutor
+	cache         Cache
+	*Blocks
 }
 
-// ensure Invoker implemented this interface
-var _ environment.Blocks = (*Invoker)(nil)
-
 // New returns a new Invoker with the given configuration.
-func New(index archive.Reader, options ...func(*Config)) (*Invoker, error) {
-
-	// Initialize the invoker configuration with conservative default values.
-	cfg := Config{
-		CacheSize: uint64(100_000_000), // ~100 MB default size
-	}
-
-	// Apply the option parameters provided by consumer.
-	for _, option := range options {
-		option(&cfg)
-	}
-
-	// Initialize interpreter and virtual machine for execution.
-	vm := fvm.NewVirtualMachine()
+func New(
+	index archive.Reader,
+	cfg Config,
+) (*Invoker, error) {
 
 	// Initialize the Ristretto cache with the size limit. Ristretto recommends
 	// keeping ten times as many counters as items in the cache when full.
@@ -55,17 +47,57 @@ func New(index archive.Reader, options ...func(*Config)) (*Invoker, error) {
 		return nil, fmt.Errorf("could not initialize cache: %w", err)
 	}
 
-	i := Invoker{
-		index: index,
-		vm:    vm,
-		cache: cache,
+	blocks := NewBlocks(index)
+
+	// This is copied code from flow-go engine/execution/computation/manager.go
+	// Ideally the same code would be used, but that requires flow-go changes.
+	// TODO: reuse code from flow-go
+	var vm fvm.VM
+	if cfg.NewCustomVirtualMachine != nil {
+		vm = cfg.NewCustomVirtualMachine()
+	} else {
+		vm = fvm.NewVirtualMachine()
 	}
 
-	vmCtx := fvm.NewContext(fvm.WithBlocks(&i))
+	chainID := cfg.ChainID
+	fvmOptions := []fvm.Option{
+		fvm.WithReusableCadenceRuntimePool(
+			reusableRuntime.NewReusableCadenceRuntimePool(
+				computation.ReusableCadenceRuntimePoolSize,
+				runtime.Config{
+					TracingEnabled:        cfg.CadenceTracing,
+					AccountLinkingEnabled: true,
+					// Attachments are enabled everywhere except for Mainnet
+					AttachmentsEnabled: chainID != flow.Mainnet,
+					// Capability Controllers are enabled everywhere except for Mainnet
+					CapabilityControllersEnabled: chainID != flow.Mainnet,
+				},
+			),
+		),
+		fvm.WithBlocks(blocks),
+	}
 
-	i.vmCtx = vmCtx
+	vmCtx := fvm.NewContext(fvmOptions...)
+	derivedChainData, err := derived.NewDerivedChainData(cfg.DerivedDataCacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create derived data cache: %w", err)
+	}
 
-	return &i, nil
+	queryExecutor := query.NewQueryExecutor(
+		cfg.QueryConfig,
+		zerolog.Nop(),            // TODO: add logger
+		&metrics.NoopCollector{}, // TODO: add metrics
+		vm,
+		vmCtx,
+		derivedChainData,
+	)
+
+	return &Invoker{
+		Blocks:        blocks,
+		index:         index,
+		cache:         cache,
+		queryExecutor: queryExecutor,
+	}, nil
 }
 
 // Key returns the public key of the account with the given address.
@@ -102,18 +134,16 @@ func (i *Invoker) Account(height uint64, address flow.Address) (*flow.Account, e
 		return nil, fmt.Errorf("could not get header: %w", err)
 	}
 
-	ctx := fvm.NewContextFromParent(i.vmCtx, fvm.WithBlockHeader(header))
-
-	account, err := i.vm.GetAccount(ctx, address, i.storageSnapshot(height))
-	if err != nil {
-		return nil, fmt.Errorf("could not get account at height %d: %w", header.Height, err)
-	}
-
-	return account, nil
+	return i.queryExecutor.GetAccount(
+		context.Background(), // TODO: add context
+		address,
+		header,
+		i.storageSnapshot(height),
+	)
 }
 
 // Script executes the given Cadence script and returns its result.
-func (i *Invoker) Script(height uint64, script []byte, args [][]byte) (cadence.Value, error) {
+func (i *Invoker) Script(height uint64, script []byte, args [][]byte) ([]byte, error) {
 	err := util.ValidateHeightDataAvailable(i.index, height)
 	if err != nil {
 		return nil, err
@@ -124,43 +154,13 @@ func (i *Invoker) Script(height uint64, script []byte, args [][]byte) (cadence.V
 		return nil, fmt.Errorf("could not get header: %w", err)
 	}
 
-	ctx := fvm.NewContextFromParent(i.vmCtx, fvm.WithBlockHeader(header))
-
-	// Initialize the procedure using the script bytes and the encoded
-	// Cadence parameters.
-	proc := fvm.Script(script).WithArguments(args...)
-
-	// The script procedure is then run using the Flow virtual machine and all
-	// the constructed contextual parameters.
-	_, output, err := i.vm.Run(ctx, proc, i.storageSnapshot(height))
-	if err != nil {
-		return nil, fmt.Errorf("could not run script: %w", err)
-	}
-	if output.Err != nil {
-		return nil, fmt.Errorf("script execution encountered error: %w", output.Err)
-	}
-
-	return output.Value, nil
-}
-
-// ByHeightFrom implements the fvm/env/blocks interface
-func (i *Invoker) ByHeightFrom(height uint64, header *flow.Header) (*flow.Header, error) {
-	if header.Height == height {
-		return header, nil
-	}
-
-	if height > header.Height {
-		minHeight, err := i.index.First()
-		if err != nil {
-			return nil, fmt.Errorf("could not find first indexed height: %w", err)
-		}
-		// imitate flow-go error format
-		err = errors.NewValueErrorf(fmt.Sprint(height),
-			"requested height (%d) is not in the range(%d, %d)", height, minHeight, header.Height)
-		return nil, fmt.Errorf("cannot retrieve block parent: %w", err)
-	}
-	// find the block in storage as all of them are guaranteed to be finalized
-	return i.index.Header(height)
+	return i.queryExecutor.ExecuteScript(
+		context.Background(), // TODO: add context
+		script,
+		args,
+		header,
+		i.storageSnapshot(height),
+	)
 }
 
 func (i *Invoker) storageSnapshot(height uint64) snapshot.StorageSnapshot {

--- a/testing/mocks/invoker.go
+++ b/testing/mocks/invoker.go
@@ -3,14 +3,14 @@ package mocks
 import (
 	"testing"
 
-	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow-go/model/flow"
 )
 
 type Invoker struct {
 	KeyFunc     func(height uint64, address flow.Address, index int) (*flow.AccountPublicKey, error)
 	AccountFunc func(height uint64, address flow.Address) (*flow.Account, error)
-	ScriptFunc  func(height uint64, script []byte, parameters [][]byte) (cadence.Value, error)
+	ScriptFunc  func(height uint64, script []byte, parameters [][]byte) ([]byte, error)
 }
 
 func BaselineInvoker(t *testing.T) *Invoker {
@@ -23,8 +23,8 @@ func BaselineInvoker(t *testing.T) *Invoker {
 		AccountFunc: func(height uint64, address flow.Address) (*flow.Account, error) {
 			return &GenericAccount, nil
 		},
-		ScriptFunc: func(height uint64, script []byte, parameters [][]byte) (cadence.Value, error) {
-			return GenericAmount(0), nil
+		ScriptFunc: func(height uint64, script []byte, parameters [][]byte) ([]byte, error) {
+			return json.MustEncode(GenericAmount(0)), nil
 		},
 	}
 
@@ -39,6 +39,6 @@ func (i *Invoker) Account(height uint64, address flow.Address) (*flow.Account, e
 	return i.AccountFunc(height, address)
 }
 
-func (i *Invoker) Script(height uint64, script []byte, parameters [][]byte) (cadence.Value, error) {
+func (i *Invoker) Script(height uint64, script []byte, parameters [][]byte) ([]byte, error) {
 	return i.ScriptFunc(height, script, parameters)
 }


### PR DESCRIPTION
## Goal of this PR

Instead of reusing the flow-go code to setup the FVM I opted for copying it over, since reuse is not that simple currently. 

The next step would be to change flow-go to allow for the reuse of the logic that sets up QueryExecutor.

I left some todos in there for logging and reporting, I'll address that next.

### Misc

- [ ] PR title will be clear as part of the changelog
- [ ] PR is against the correct branch
- [ ] PR is labelled appropriately
- [ ] PR is linked to an issue