### PR TITLE
Fix invoker FVM configs

### DIFF
--- a/cmd/flow-archive-client/main.go
+++ b/cmd/flow-archive-client/main.go
@@ -128,13 +128,14 @@ func run() int {
 		return failure
 	}
 
+	config := invoker.DefaultConfig
+	config.ChainID = chainID
+	config.CacheSize = flagCache
+
 	invoke, err := invoker.New(
 		log,
 		read,
-		invoker.Config{
-			CacheSize: flagCache,
-			ChainID:   chainID,
-		})
+		config)
 	if err != nil {
 		log.Error().Err(err).Msg("could not initialize invoker")
 		return failure

--- a/cmd/flow-archive-live/main.go
+++ b/cmd/flow-archive-live/main.go
@@ -394,13 +394,13 @@ func run() int {
 	}
 
 	log.Info().Msgf("Creating local invoker with register cache: %d", flagCache)
+	config := invoker.DefaultConfig
+	config.ChainID = chainID
+	config.CacheSize = flagCache
 	invoke, err := invoker.New(
 		log,
 		read,
-		invoker.Config{
-			CacheSize: flagCache,
-			ChainID:   chainID,
-		},
+		config,
 	)
 	if err != nil {
 		log.Error().Err(err).Msg("could not initialize script invoker")

--- a/cmd/flow-archive-live/main.go
+++ b/cmd/flow-archive-live/main.go
@@ -529,7 +529,7 @@ func run() int {
 func getChainId(read *index.Reader) (flowModel.ChainID, error) {
 	chainID := flowModel.Emulator
 
-	f, err := read.First()
+	f, err := read.Last()
 	if err != nil {
 		return chainID, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/klauspost/compress v1.15.15
-	github.com/onflow/cadence v0.39.9
+	github.com/onflow/cadence v0.39.14
 	github.com/onflow/flow-go-sdk v0.41.5
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/tsdb v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -1203,8 +1203,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/atree v0.6.0 h1:j7nQ2r8npznx4NX39zPpBYHmdy45f4xwoi+dm37Jk7c=
 github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVFi0tc=
-github.com/onflow/cadence v0.39.9 h1:QCVZtHDbqfeqbB8rFIqPBqFY+rYLpC0VYSwDGmiNTec=
-github.com/onflow/cadence v0.39.9/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
+github.com/onflow/cadence v0.39.14 h1:YoR3YFUga49rqzVY1xwI6I2ZDBmvwGh13jENncsleC8=
+github.com/onflow/cadence v0.39.14/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.3 h1:wV+gcgOY0oJK4HLZQYQoK+mm09rW1XSxf83yqJwj0n4=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.3/go.mod h1:Osvy81E/+tscQM+d3kRFjktcIcZj2bmQ9ESqRQWDEx8=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3 h1:X25A1dNajNUtE+KoV76wQ6BR6qI7G65vuuRXxDDqX7E=

--- a/service/invoker/config.go
+++ b/service/invoker/config.go
@@ -32,4 +32,5 @@ var DefaultConfig = Config{
 		},
 		DerivedDataCacheSize: derived.DefaultDerivedDataCacheSize,
 	},
+	ChainID: flow.Emulator,
 }

--- a/service/invoker/invoker.go
+++ b/service/invoker/invoker.go
@@ -77,6 +77,7 @@ func New(
 		),
 		fvm.WithBlocks(blocks),
 		fvm.WithLogger(log),
+		fvm.WithChain(chainID.Chain()),
 	}
 
 	vmCtx := fvm.NewContext(fvmOptions...)


### PR DESCRIPTION
## Goal of this PR
Fix the following Issues:
- Obtain chainID from latest block instead of `first()` as this may not have been indexed yet at bootstrap
- assign `Emulator` as the default chainID in the invoker config, the same as in `archive-live-server`
- Update cadence dependency to the latest public version to avoid divergent script execution output