### PR TITLE
Add validation for trie updates

### DIFF
--- a/cmd/flow-archive-live/main.go
+++ b/cmd/flow-archive-live/main.go
@@ -73,6 +73,7 @@ func run() int {
 		flagBucket           string
 		flagCheckpoint       string
 		flagData             string
+		flagExecAddress      string
 		flagIndex            string
 		flagLevel            string
 		flagFollowerLogLevel string
@@ -112,6 +113,7 @@ func run() int {
 	pflag.StringVar(&flagSeedAddress, "seed-address", "", "host address of seed node to follow consensus")
 	pflag.StringVar(&flagSeedKey, "seed-key", "", "hex-encoded public network key of seed node to follow consensus")
 	pflag.BoolVarP(&flagTracing, "tracing", "t", false, "enable tracing for this instance")
+	pflag.StringVar(&flagExecAddress, "exec-address", "", "host address of access node to get exec data from")
 
 	pflag.Parse()
 
@@ -310,7 +312,7 @@ func run() int {
 	)
 	// create exec data client from seed address
 	conn, err := grpc.Dial(
-		flagSeedAddress,
+		flagExecAddress,
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxGrpcMsgSize)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {


### PR DESCRIPTION
## Goal of this PR
- Adds a new flag to `archive-live` to get an address of an AN that can serve Execdata API
- Adds a procedure to `Execution` to fetch `TrieUpdates` from exec data API and compare it with the updates from GCP

Alternatively, we could skip the comparison and just relay on exec data itself, since it's our source of truth 