### PR TITLE
Add deprecation notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Deprecated
+
+The flow data provisioning service is deprecated. The functionality is now available as part for the Flow Access node.
+
 # Flow Data Provisioning Service
 
 [![CI Status](https://img.shields.io/github/workflow/status/optakt/flow-dps/MasterCI?logo=GitHub%20Actions&label=&logoColor=silver&labelColor=gray)](https://github.com/optakt/flow-dps/actions/workflows/master.yml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deprecated
 
-The flow data provisioning service is deprecated. The functionality is now available as part for the Flow Access node.
+The Flow Data Provisioning Service is deprecated. This functionality is now available as part of the Flow Access node.
 
 # Flow Data Provisioning Service
 


### PR DESCRIPTION
The functionality of indexing execution data and supporting script execution is now a native feature of the Access node. Adding a deprecation notice to the readme to make clear this repo is no used.